### PR TITLE
Fix slow and unclean shutdown when using child_spec/{2,3}

### DIFF
--- a/src/poolgirl.erl
+++ b/src/poolgirl.erl
@@ -48,8 +48,8 @@ child_spec(PoolId, PoolArgs) ->
                  WorkerArgs :: proplists:proplist())
     -> supervisor:child_spec().
 child_spec(PoolId, PoolArgs, WorkerArgs) ->
-    {PoolId, {poolgirl, start_link, [PoolArgs, WorkerArgs]},
-     permanent, 5000, worker, [poolgirl]}.
+    {PoolId, {poolgirl_sup, start_link, [PoolArgs, WorkerArgs]},
+     permanent, 5000, supervisor, [poolgirl]}.
 
 -spec start_link(PoolArgs :: proplists:proplist())
     -> start_ret().


### PR DESCRIPTION
Launch child_spec/{2,3} -specified children under the caller's own
supervision tree, lest we end up with the same child (poolgirl_sup)
under two supervisors (poolgirl_app_sup and the client application one.)